### PR TITLE
Day 10: Add IP-based login rate limiting with Bucket4j and 429 handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,14 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
+		<!-- For Java 17+ -->
+		<dependency>
+			<groupId>com.bucket4j</groupId>
+			<artifactId>bucket4j_jdk17-core</artifactId>
+			<version>8.15.0</version>
+		</dependency>
+
+
 
 		<dependency>
 			<groupId>org.springdoc</groupId>

--- a/src/main/java/com/taskmanager/taskmanager_api/controller/AuthController.java
+++ b/src/main/java/com/taskmanager/taskmanager_api/controller/AuthController.java
@@ -3,8 +3,12 @@ package com.taskmanager.taskmanager_api.controller;
 import com.taskmanager.taskmanager_api.dto.AuthResponse;
 import com.taskmanager.taskmanager_api.dto.LoginRequest;
 import com.taskmanager.taskmanager_api.dto.RegisterRequest;
+import com.taskmanager.taskmanager_api.exception.TooManyRequestsException;
 import com.taskmanager.taskmanager_api.service.AuthService;
+import com.taskmanager.taskmanager_api.service.RateLimitService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,6 +19,8 @@ public class AuthController {
     // authservice
     private final AuthService authService;
 
+    @Autowired
+    private RateLimitService rateLimitService;
 
     @PostMapping("/register")
     public String register(@RequestBody RegisterRequest request)
@@ -23,9 +29,24 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request){
+    public ResponseEntity<AuthResponse> login(@RequestBody LoginRequest request, HttpServletRequest httpRequest){
+        String ip=httpRequest.getRemoteAddr();
+
+        if(!rateLimitService.allowLoginRequests(ip)){
+            throw new TooManyRequestsException(
+                    "Too many login attempts. Try again after 1 minute."
+            );
+        }
         return ResponseEntity.ok(authService.login(request));
     }
-
-
 }
+
+
+//Client hits /auth/login
+//Server extracts IP address
+//IP goes into RateLimitService
+//Bucket checks token:
+//✅ token available → login allowed
+//❌ no token → exception thrown
+//Exception caught by GlobalExceptionHandler
+//Client receives 429

--- a/src/main/java/com/taskmanager/taskmanager_api/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/taskmanager/taskmanager_api/exception/GlobalExceptionHandler.java
@@ -69,5 +69,21 @@ public ResponseEntity<Map<String,Object>> handleGeneral(Exception ex){
 
 
 
+@ExceptionHandler(TooManyRequestsException.class)
+public ResponseEntity<Map<String,Object>> handleTooManyRequests(TooManyRequestsException ex){
+        Map<String,Object>error=new HashMap<>();
+            error.put("timestamp",LocalDateTime.now());
+            error.put("error",ex.getMessage());
+
+            return new ResponseEntity<>(error,HttpStatus.TOO_MANY_REQUESTS);
+}
+//    jab rate limit exceed hoga → ye handler chalega
+//    HTTP Status = 429
+//    Response clean rahega (no server crash)
+
+
+
+
+
 }
 

--- a/src/main/java/com/taskmanager/taskmanager_api/exception/TooManyRequestsException.java
+++ b/src/main/java/com/taskmanager/taskmanager_api/exception/TooManyRequestsException.java
@@ -1,0 +1,10 @@
+package com.taskmanager.taskmanager_api.exception;
+
+public class TooManyRequestsException extends RuntimeException{
+    public TooManyRequestsException(String message){
+        super(message);
+    }
+}
+
+// We don’t want to return 500 error
+//We want proper HTTP 429 Too Many Requests

--- a/src/main/java/com/taskmanager/taskmanager_api/service/RateLimitService.java
+++ b/src/main/java/com/taskmanager/taskmanager_api/service/RateLimitService.java
@@ -1,0 +1,40 @@
+package com.taskmanager.taskmanager_api.service;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+public class RateLimitService {
+
+    // IP->token bucket Thread safe
+    private final Map<String,Bucket> loginBuckets=new ConcurrentHashMap<>();
+
+    // bucket creation : 5 request per minute
+    private Bucket createLoginBucket(String ip){
+        System.out.println("Creating new bucket for IP: " + ip);
+        Bandwidth limit=Bandwidth.builder()
+                .capacity(5)  // max tokens
+                .refillGreedy(5, Duration.ofMinutes(1)) // refill 5 tokens every 1 minute
+                .build();
+
+        return Bucket.builder()
+                .addLimit(limit)
+                .build();
+    }
+
+    public boolean allowLoginRequests(String ip){
+        Bucket bucket=loginBuckets.computeIfAbsent(ip,this::createLoginBucket);
+        return bucket.tryConsume(1);
+    }
+
+}
+
+// AIM:
+//Create one token bucket per IP
+//Allow 5 login requests per minute
+//On 6th request → return 429 Too Many Requests


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added rate limiting to the login endpoint—users are limited to 5 login attempts per minute per IP address. Requests exceeding this limit receive an HTTP 429 (Too Many Requests) response.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->